### PR TITLE
width hotfix for smaller screens

### DIFF
--- a/src/components/Calendar/Calendar.module.css
+++ b/src/components/Calendar/Calendar.module.css
@@ -3,6 +3,7 @@
 }
 
 .react-calendar {
+	width: "250%";
 	max-width: 300px;
 	box-shadow: 5px 3px 12px 0px rgba(16, 36, 94, 0.2);
 	position: absolute;


### PR DESCRIPTION
I have fixed a issue where the input field is smaller and only 5 days or less are shown in week, we can fix it by having higher width and max width will handle over width. 
**Before**
![image](https://github.com/sbmdkl/nepali-datepicker-reactjs/assets/78496762/819ae10c-0043-4444-b23f-49f26d2bc6d2)
**After**
![image](https://github.com/sbmdkl/nepali-datepicker-reactjs/assets/78496762/186f3053-5d0a-4f03-b36b-1d034eb7ef37)
